### PR TITLE
DEVOPS-571 Update to support db names that don't conflict with ruby syntax

### DIFF
--- a/templates/model.rb.j2
+++ b/templates/model.rb.j2
@@ -62,8 +62,8 @@ TemplateModel.new(:{{ item.key }}, "{{ microservice_name }} {{ microservice_env 
 
 {% if backup.mysql is defined %}
 {% for database in backup.mysql %}
-  database MySQL, :{{ database }} do |db|
-    db.name               = "{{ database }}"
+  database MySQL, :{{ database.label }} do |db|
+    db.name               = "{{ database.name }}"
   end
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
This change was needed as mysql databases with `-` in them where causing an error:

Now that label can be a ruby friendly name and the database name can be anything.

new format of data looks like this:
```
backup_jobs:
  job:
    schedule: "@daily"
    keep: "4"
    local:
      path: "/data/backups"
    mysql:
      - wwwsafetyculturecom:
        label: wwwsafetyculturecom
        name: www-safetyculture-com
      - supportsafetyculturecom:
        label: supportsafetyculturecom
        name: support-safetyculture-com
    archives:
      add:
        - "/data/wp-content"
```